### PR TITLE
Fix docstring typos

### DIFF
--- a/fmc_rest/fmc_rest.py
+++ b/fmc_rest/fmc_rest.py
@@ -24,7 +24,7 @@ class FMCException(Exception):
 
 
 class FMCRest(object):
-    """FMC Reset API utility class
+    """FMC REST API utility class
     """
 
     AUTH_PATH = "fmc_platform/v1/auth/generatetoken"
@@ -178,7 +178,7 @@ class FMCRest(object):
             raise err
 
 class cdFMCRest(FMCRest):
-    """cdFMC Reset API utility class
+    """cdFMC REST API utility class
     """
 
     CDFMC_HOST_ENDPOINT= 'aegis/rest/v1/services/targets/devices?q=deviceType:FMCE'


### PR DESCRIPTION
## Summary
- fix typos in REST API class docstrings

## Testing
- `python3 -m py_compile fmc_rest/fmc_rest.py`


------
https://chatgpt.com/codex/tasks/task_b_6865f8ca03848329a09162fb7ff3ae67