### PR TITLE
Fix auth status code check

### DIFF
--- a/fmc_rest/fmc_rest.py
+++ b/fmc_rest/fmc_rest.py
@@ -85,7 +85,7 @@ class FMCRest(object):
                 logging.debug("Login Authentication")
                 resp = self.session.post(self.base_url + FMCRest.AUTH_PATH,
                                          auth=requests.auth.HTTPBasicAuth(username, password))
-                if resp.status_code >= 300 and resp.status_code < 200:
+                if not 200 <= resp.status_code < 300:
                     logging.error('Authentication Failed')
                     resp.raise_for_status()
 


### PR DESCRIPTION
## Summary
- fix range logic when checking authentication responses

## Testing
- `python -m py_compile fmc_rest/fmc_rest.py`


------
https://chatgpt.com/codex/tasks/task_b_6865f8db00e88329b7f5275e25ae6c38