### PR TITLE
Add basic tests for public API and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,8 @@ Usage:
     -t --token TOKEN    CDO API token (Please use ~/.cdo_token file or CDO_TOKEN env var instead)
     -r --region REGION  CDO Region. Must be one of: "us", "eu", or "apj" Default: us
     -b, --bulk          Process all the Access Policies on the FMC at once
+## Running Tests
+
+Install test requirements and run:
+
+    pytest

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Usage:
     -t --token TOKEN    CDO API token (Please use ~/.cdo_token file or CDO_TOKEN env var instead)
     -r --region REGION  CDO Region. Must be one of: "us", "eu", or "apj" Default: us
     -b, --bulk          Process all the Access Policies on the FMC at once
+
 ## Running Tests
 
 Install test requirements and run:

--- a/fmc_rest/fmc_rest.py
+++ b/fmc_rest/fmc_rest.py
@@ -13,7 +13,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 # Explicitly export symbols
-__all__ = ['FMCRest', 'cdFMCRest' 'FMCException']
+__all__ = ['FMCRest', 'cdFMCRest', 'FMCException']
 
 class FMCException(Exception):
     """ Utility exception for Module specific errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+addopts = "-vv"
+testpaths = ["tests"]

--- a/tests/test_fmc_rest.py
+++ b/tests/test_fmc_rest.py
@@ -1,0 +1,53 @@
+import sys
+import pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import types
+from unittest.mock import MagicMock
+import pytest
+
+
+def _install_requests_stub(monkeypatch):
+    requests = types.ModuleType('requests')
+    packages = types.ModuleType('requests.packages')
+    urllib3_pkg = types.ModuleType('requests.packages.urllib3')
+    exceptions_pkg = types.ModuleType('requests.packages.urllib3.exceptions')
+    InsecureRequestWarning = type('InsecureRequestWarning', (), {})
+    exceptions_pkg.InsecureRequestWarning = InsecureRequestWarning
+    urllib3_pkg.exceptions = exceptions_pkg
+    urllib3_pkg.disable_warnings = lambda *a, **k: None
+    packages.urllib3 = urllib3_pkg
+    requests.packages = packages
+    requests.Session = lambda: types.SimpleNamespace()
+    requests.auth = types.SimpleNamespace(HTTPBasicAuth=object)
+    requests.exceptions = types.SimpleNamespace(HTTPError=Exception)
+    monkeypatch.setitem(sys.modules, 'requests', requests)
+    monkeypatch.setitem(sys.modules, 'requests.packages', packages)
+    monkeypatch.setitem(sys.modules, 'requests.packages.urllib3', urllib3_pkg)
+    monkeypatch.setitem(sys.modules, 'requests.packages.urllib3.exceptions', exceptions_pkg)
+
+
+def test_star_import_provides_symbols(monkeypatch):
+    _install_requests_stub(monkeypatch)
+    namespace = {}
+    exec('from fmc_rest import *', namespace)
+    assert 'FMCRest' in namespace
+    assert 'cdFMCRest' in namespace
+    assert 'FMCException' in namespace
+
+
+def test_request_invalid_verb_raises(monkeypatch):
+    _install_requests_stub(monkeypatch)
+    from fmc_rest import FMCRest, FMCException
+
+    fmc = object.__new__(FMCRest)
+    fmc.session = types.SimpleNamespace(
+        get=MagicMock(),
+        post=MagicMock(),
+        put=MagicMock(),
+        delete=MagicMock(),
+    )
+    fmc.base_url = ''
+    fmc._auth = lambda *a, **kw: None
+
+    with pytest.raises(FMCException):
+        fmc._request('BAD', '/foo')


### PR DESCRIPTION
## Summary
- add initial pytest configuration
- write tests for FMCRest exports and invalid verb handling
- document how to run the test suite
- fix `__all__` list in `fmc_rest.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865f8d54dac8329a4b8ae2173409a8e